### PR TITLE
make the loading of b2c.json file dynamic instead of hard coded

### DIFF
--- a/tests/src/generate_plugin_config.js
+++ b/tests/src/generate_plugin_config.js
@@ -40,7 +40,7 @@ function generate_plugin_config() {
 	}
 	
 	// Load the b2c.json file
-	const b2c = require(`../boilerplate/b2c.json`);
+	const b2c = require(`../${pluginFolder}/b2c.json`);
 	
 	let res = {};
 	

--- a/tests/src/swap_exact_eth_for_tokens.test.js
+++ b/tests/src/swap_exact_eth_for_tokens.test.js
@@ -8,7 +8,7 @@ import { parseEther, parseUnits} from "ethers/lib/utils";
 const contractAddr = "0x7a250d5630b4cf539739df2c5dacb4c659f2488d";
 // EDIT THIS: Replace `boilerplate` with your plugin name
 const pluginName = "boilerplate";
-const abi_path = `../${pluginname}/abis/` + contractAddr + '.json';
+const abi_path = `../${pluginName}/abis/` + contractAddr + '.json';
 const abi = require(abi_path);
 
 


### PR DESCRIPTION
Currently today the loading of the b2c.json file is hard coded in the testing.

I would like to propose that the dynamic variable be used ${pluginFolder} instead of hard-coding it to "boilerplate"