### PR TITLE
Remove derivation on m/45'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ include $(BOLOS_SDK)/Makefile.defines
 # EDIT THIS: Put your plugin name
 APPNAME = "Boilerplate"
 
-APP_LOAD_PARAMS += --appFlags 0x800 --path "44'/60'" --path "45'" --curve secp256k1
+APP_LOAD_PARAMS += --appFlags 0x800 --path "44'/60'" --curve secp256k1
 
 APP_LOAD_PARAMS += $(COMMON_LOAD_PARAMS)
 


### PR DESCRIPTION
`m/45'` is used on the Ethereum app it was used by RSK.
There is no reason to keep it in plugins.