### PR TITLE
Correctness improvements

### DIFF
--- a/src/handle_init_contract.c
+++ b/src/handle_init_contract.c
@@ -49,6 +49,7 @@ void handle_init_contract(void *parameters) {
             break;
         case BOILERPLATE_DUMMY_2:
             context->next_param = TOKEN_RECEIVED;
+            break;
         // Keep this
         default:
             PRINTF("Missing selectorIndex: %d\n", context->selectorIndex);

--- a/src/handle_provide_parameter.c
+++ b/src/handle_provide_parameter.c
@@ -2,7 +2,7 @@
 
 // Copies the whole parameter (32 bytes long) from `src` to `dst`.
 // Useful for numbers, data...
-static void copy_parameter(uint8_t *dst, size_t dst_len, uint8_t *src) {
+static void copy_parameter(uint8_t *dst, size_t dst_len, const uint8_t *src) {
     // Take the minimum between dst_len and parameter_length to make sure we don't overwrite memory.
     size_t len = MIN(dst_len, PARAMETER_LENGTH);
     memcpy(dst, src, len);
@@ -10,7 +10,7 @@ static void copy_parameter(uint8_t *dst, size_t dst_len, uint8_t *src) {
 
 // Copies a 20 byte address (located in a 32 bytes parameter) `from `src` to `dst`.
 // Useful for token addresses, user addresses...
-static void copy_address(uint8_t *dst, size_t dst_len, uint8_t *src) {
+static void copy_address(uint8_t *dst, size_t dst_len, const uint8_t *src) {
     // An address is 20 bytes long: so we need to make sure we skip the first 12 bytes!
     size_t offset = PARAMETER_LENGTH - ADDRESS_LENGTH;
     size_t len = MIN(dst_len, ADDRESS_LENGTH);

--- a/src/handle_query_contract_id.c
+++ b/src/handle_query_contract_id.c
@@ -3,7 +3,7 @@
 // Sets the first screen to display.
 void handle_query_contract_id(void *parameters) {
     ethQueryContractID_t *msg = (ethQueryContractID_t *) parameters;
-    context_t *context = (context_t *) msg->pluginContext;
+    const context_t *context = (const context_t *) msg->pluginContext;
     // msg->name will be the upper sentence displayed on the screen.
     // msg->version will be the lower sentence displayed on the screen.
 
@@ -11,16 +11,11 @@ void handle_query_contract_id(void *parameters) {
     strlcpy(msg->name, PLUGIN_NAME, msg->nameLength);
 
     // EDIT THIS: Adapt the cases by modifying the strings you pass to `strlcpy`.
-    switch (context->selectorIndex) {
-        case SWAP_EXACT_ETH_FOR_TOKENS:
-            strlcpy(msg->version, "Swap", msg->versionLength);
-            break;
-        // Keep this
-        default:
-            PRINTF("Selector index: %d not supported\n", context->selectorIndex);
-            msg->result = ETH_PLUGIN_RESULT_ERROR;
-            return;
+    if (context->selectorIndex == SWAP_EXACT_ETH_FOR_TOKENS) {
+        strlcpy(msg->version, "Swap", msg->versionLength);
+        msg->result = ETH_PLUGIN_RESULT_OK;
+    } else {
+        PRINTF("Selector index: %d not supported\n", context->selectorIndex);
+        msg->result = ETH_PLUGIN_RESULT_ERROR;
     }
-
-    msg->result = ETH_PLUGIN_RESULT_OK;
 }

--- a/src/handle_query_contract_ui.c
+++ b/src/handle_query_contract_ui.c
@@ -8,7 +8,7 @@
 static void set_send_ui(ethQueryContractUI_t *msg) {
     strlcpy(msg->title, "Send", msg->titleLength);
 
-    uint8_t *eth_amount = msg->pluginSharedRO->txContent->value.value;
+    const uint8_t *eth_amount = msg->pluginSharedRO->txContent->value.value;
     uint8_t eth_amount_size = msg->pluginSharedRO->txContent->value.length;
 
     // Converts the uint256 number located in `eth_amount` to its string representation and
@@ -18,11 +18,11 @@ static void set_send_ui(ethQueryContractUI_t *msg) {
 
 // Set UI for "Receive" screen.
 // EDIT THIS: Adapt / remove this function to your needs.
-static void set_receive_ui(ethQueryContractUI_t *msg, context_t *context) {
+static void set_receive_ui(ethQueryContractUI_t *msg, const context_t *context) {
     strlcpy(msg->title, "Receive Min.", msg->titleLength);
 
     uint8_t decimals = context->decimals;
-    char *ticker = context->ticker;
+    const char *ticker = context->ticker;
 
     // If the token look up failed, use the default network ticker along with the default decimals.
     if (!context->token_found) {

--- a/src/main.c
+++ b/src/main.c
@@ -94,7 +94,7 @@ __attribute__((section(".boot"))) int main(int arg0) {
                 return 0;
             } else {
                 // Not called from dashboard: called from the ethereum app!
-                unsigned int *args = (unsigned int *) arg0;
+                const unsigned int *args = (const unsigned int *) arg0;
 
                 // If `ETH_PLUGIN_CHECK_PRESENCE` is set, this means the caller is just trying to
                 // know whether this app exists or not. We can skip `dispatch_plugin_calls`.


### PR DESCRIPTION
Bugfix: add a missing break in a switch. Previously, all calls to `BOILERPLATE_DUMMY_2` seemed to lead to an error.

Moreover, code has been slightly modified to make it (I think) more readable.