### PR TITLE
Refactor search for selectors

### DIFF
--- a/src/boilerplate_plugin.h
+++ b/src/boilerplate_plugin.h
@@ -32,7 +32,7 @@ typedef enum {
 } parameter;
 
 // EDIT THIS: Rename `BOILERPLATE` to be the same as the one initialized in `main.c`.
-extern const uint8_t *const BOILERPLATE_SELECTORS[NUM_SELECTORS];
+extern const uint32_t BOILERPLATE_SELECTORS[NUM_SELECTORS];
 
 // Shared global memory with Ethereum app. Must be at most 5 * 32 bytes.
 // EDIT THIS: This struct is used by your plugin to save the parameters you parse. You

--- a/src/handle_init_contract.c
+++ b/src/handle_init_contract.c
@@ -35,7 +35,6 @@ void handle_init_contract(void *parameters) {
     // Initialize the context (to 0).
     memset(context, 0, sizeof(*context));
 
-    // Look for the index of the selectorIndex passed in by `msg`.
     uint32_t selector = U4BE(msg->selector, 0);
     if (find_selector(selector, BOILERPLATE_SELECTORS, NUM_SELECTORS, &context->selectorIndex)) {
         msg->result = ETH_PLUGIN_RESULT_UNAVAILABLE;

--- a/src/handle_init_contract.c
+++ b/src/handle_init_contract.c
@@ -1,5 +1,15 @@
 #include "boilerplate_plugin.h"
 
+static int find_selector(uint32_t selector, const uint32_t *selectors, size_t n, selector_t *out) {
+    for (selector_t i = 0; i < n; i++) {
+        if (selector == selectors[i]) {
+            *out = i;
+            return 0;
+        }
+    }
+    return -1;
+}
+
 // Called once to init.
 void handle_init_contract(void *parameters) {
     // Cast the msg to the type of structure we expect (here, ethPluginInitContract_t).
@@ -27,16 +37,7 @@ void handle_init_contract(void *parameters) {
 
     // Look for the index of the selectorIndex passed in by `msg`.
     uint32_t selector = U4BE(msg->selector, 0);
-    int i;
-    for (i = 0; i < NUM_SELECTORS; i++) {
-        if (selector == BOILERPLATE_SELECTORS[i]) {
-            context->selectorIndex = i;
-            break;
-        }
-    }
-
-    // If `i == NUM_SELECTORS` it means we haven't found the selector. Return an error.
-    if (i == NUM_SELECTORS) {
+    if (find_selector(selector, BOILERPLATE_SELECTORS, NUM_SELECTORS, &context->selectorIndex)) {
         msg->result = ETH_PLUGIN_RESULT_UNAVAILABLE;
         return;
     }

--- a/src/handle_init_contract.c
+++ b/src/handle_init_contract.c
@@ -26,9 +26,10 @@ void handle_init_contract(void *parameters) {
     memset(context, 0, sizeof(*context));
 
     // Look for the index of the selectorIndex passed in by `msg`.
-    uint8_t i;
+    uint32_t selector = U4BE(msg->selector, 0);
+    int i;
     for (i = 0; i < NUM_SELECTORS; i++) {
-        if (memcmp((uint8_t *) PIC(BOILERPLATE_SELECTORS[i]), msg->selector, SELECTOR_SIZE) == 0) {
+        if (selector == BOILERPLATE_SELECTORS[i]) {
             context->selectorIndex = i;
             break;
         }

--- a/src/main.c
+++ b/src/main.c
@@ -26,13 +26,13 @@
 
 // List of selectors supported by this plugin.
 // EDIT THIS: Adapt the variable names and change the `0x` values to match your selectors.
-static const uint8_t SWAP_EXACT_ETH_FOR_TOKENS_SELECTOR[SELECTOR_SIZE] = {0x7f, 0xf3, 0x6a, 0xb5};
-static const uint8_t BOILERPLATE_DUMMY_SELECTOR_2[SELECTOR_SIZE] = {0x13, 0x37, 0x42, 0x42};
+static const uint32_t SWAP_EXACT_ETH_FOR_TOKENS_SELECTOR = 0x7ff36ab5;
+static const uint32_t BOILERPLATE_DUMMY_SELECTOR_2 = 0x13374242;
 
 // Array of all the different boilerplate selectors. Make sure this follows the same order as the
 // enum defined in `boilerplate_plugin.h`
 // EDIT THIS: Use the names of the array declared above.
-const uint8_t *const BOILERPLATE_SELECTORS[NUM_SELECTORS] = {
+const uint32_t BOILERPLATE_SELECTORS[NUM_SELECTORS] = {
     SWAP_EXACT_ETH_FOR_TOKENS_SELECTOR,
     BOILERPLATE_DUMMY_SELECTOR_2,
 };


### PR DESCRIPTION
- Use 32-bit integers instead of bytes to represent method selectors.
- Add a helper function to iterate over selectors when matching input selector.