### PR TITLE
Fix fuzzer compilation by adding HAVE_SHA224

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -65,6 +65,7 @@ add_compile_definitions(
     HAVE_EDDSA
     HAVE_HASH
     HAVE_BLAKE2
+    HAVE_SHA224
     HAVE_SHA256
     HAVE_SHA3
     HAVE_SHA512


### PR DESCRIPTION
After the SDK update, a new constant definition was missing.

# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [X] App update process has been followed <!-- See comment below -->
- [X] Target branch is `develop` <!-- unless you have a very good reason -->
- [ ] Application version has been bumped <!-- required if your changes are to be deployed -->

