### PR TITLE
Update the test dependencies order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,6 @@ ledger/
 tests/snapshots-tmp/
 
 # Directory storing the ethereum build output for tests run
-tests/.test_dependencies/ethereum/*
+tests/.test_dependencies/*
+!tests/.test_dependencies/ethereum/
 !tests/.test_dependencies/ethereum/.ethereum_application_build_goes_there

--- a/ledger_app.toml
+++ b/ledger_app.toml
@@ -7,9 +7,10 @@ devices = ["nanos", "nanox", "nanos+", "stax"]
 pytest_directory = "./tests/"
 
 [tests.dependencies]
-testing_with_prod = [
-    {url = "https://github.com/LedgerHQ/app-ethereum", ref = "master", use_case = "use_test_keys"},
-]
 testing_with_latest = [
     {url = "https://github.com/LedgerHQ/app-ethereum", ref = "develop", use_case = "use_test_keys"},
+]
+
+testing_with_prod = [
+    {url = "https://github.com/LedgerHQ/app-ethereum", ref = "master", use_case = "use_test_keys"},
 ]


### PR DESCRIPTION
Update the test dependencies in order to use first the develop ethereum branch (will be used by default by Vscode extension).
