### PR TITLE
Remove duplicated mapping from clang-format config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,6 @@ SortIncludes: false
 SpaceAfterCStyleCast: true
 AllowShortCaseLabelsOnASingleLine: false
 AllowAllArgumentsOnNextLine: false
-AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortBlocksOnASingleLine: Never
 AllowShortFunctionsOnASingleLine: None
 BinPackArguments: false


### PR DESCRIPTION
The .clang-format config contained the mapping key `AllowAllParametersOfDeclarationOnNextLine` twice, which fails with the following error. (Or at least it failed for me, using `clang-format@v19.1.1`).

Error:
```plaintext
Error reading /<the-path>/.clang-format: Invalid argument
/<the-path>/.clang-format:15:1: error: duplicated mapping key 'AllowAllParametersOfDeclarationOnNextLine'
AllowAllParametersOfDeclarationOnNextLine: false
```

I am pretty sure that the duplicated line has no effect other than failing `clang-format` and therefore propose removing one instance of them.